### PR TITLE
2 userstory

### DIFF
--- a/app/controllers/plant_plots_controller.rb
+++ b/app/controllers/plant_plots_controller.rb
@@ -1,0 +1,8 @@
+class PlantPlotsController < ApplicationController
+  def destroy
+    plant_plot = PlantPlot.find(params[:id])
+    plant_plot.destroy
+
+    redirect_to plots_path
+  end
+end

--- a/app/controllers/plots_controller.rb
+++ b/app/controllers/plots_controller.rb
@@ -3,8 +3,4 @@ class PlotsController < ApplicationController
   def index
     @plots = Plot.all
   end
-
-  def destroy
-
-  end
 end

--- a/app/views/plots/index.html.erb
+++ b/app/views/plots/index.html.erb
@@ -3,10 +3,10 @@
 <% @plots.each do |plot| %>
   <div id="plot_<%= plot.id %>">
     <p>Plot number: <%= plot.number %></p>
-    <p>Plants:</p>
-    <% plot.plants.each do |plant| %>
-      <div id="plant_<%= plant.id %>">
-        <li> <%= plant.name %>
+    <b>Plants:</b>
+    <% plot.plant_plots.each do |plant_plot| %>
+      <div id="<%= plant_plot.id %>">
+        <li> <%= plant_plot.plant.name %>  <%= button_to 'Delete Plant From Plot', plant_plot_path(plant_plot), method: :delete %> <br />
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,8 @@ Rails.application.routes.draw do
   # root "articles#index"
 
   resources :plots, only: [:index]
+
+  resources :plant_plots, only: [:destroy]
+
+  # resources :plant_plots, only: [:destroy]
 end

--- a/spec/features/plots/index_spec.rb
+++ b/spec/features/plots/index_spec.rb
@@ -43,15 +43,21 @@ describe "plots index" do
   end
 
   it "has a link to delete next to each plant" do
-    within "#plant_#{@plant_1.id}" do
-      expect(page).to have_button("Delete Plant")
-      click_button "Delete Plant"
+    within "#plot_#{@plot_1.id}" do
+      within "##{@plant_plot_1.id}" do
+        expect(page).to have_button("Delete Plant From Plot")
+        click_button "Delete Plant From Plot"
+      end
     end
-    
-    expect(current_path).to eq(plant_plots_path(@plot_1, @plant_1))
+
+    expect(current_path).to eq(plots_path)
 
     within "#plot_#{@plot_1.id}" do
       expect(page).to_not have_content(@plant_1.name)
+    end
+
+    within "#plot_#{@plot_4.id}" do
+      expect(page).to have_content(@plant_1.name)
     end
   end
 end


### PR DESCRIPTION
User Story 2, Remove a Plant from a Plot

As a visitor
When I visit the plots index page
Next to each plant's name
I see a link to remove that plant from that plot
When I click on that link
I'm returned to the plots index page
And I no longer see that plant listed under that plot,
And I still see that plant's name under other plots that is was associated with.

Note: you do not need to test for any sad paths or implement any flash messages. 